### PR TITLE
Use HTML compression layout

### DIFF
--- a/_layouts/compress.html
+++ b/_layouts/compress.html
@@ -1,0 +1,55 @@
+---
+# Jekyll HTML Compression Layout
+#
+# This code is modified from <https://github.com/penibelst/jekyll-compress-html>.
+# Licensed under the MIT License.
+---
+
+{%- capture _LINE_FEED %}
+{% endcapture -%}
+
+{%- if jekyll.environment == 'development' -%}
+  {{ content }}
+{%- endif -%}
+
+
+{%- comment -%} Initialization {%- endcomment -%}
+
+  {%- capture _content -%}{{ content }}{%- endcapture -%}
+
+
+{%- comment -%} Remove blanklines {%- endcomment -%}
+
+  {%- assign _pre_befores = _content | split: "<pre" -%}
+  {%- assign _content = "" -%}
+
+  {%- for _pre_before in _pre_befores -%}
+    {%- assign _pres = _pre_before | split: "</pre>" -%}
+    {%- assign _pre_after = "" -%}
+
+    {%- if _pres.size != 0 -%}
+      {%- assign _lines = _pres.last | split: _LINE_FEED -%}
+      {%- capture _pres_after -%}
+        {%- for _line in _lines -%}
+          {%- assign _trimmed = _line | split: " " | join: " " -%}
+          {%- if _trimmed != empty or forloop.last -%}
+            {%- unless forloop.first -%}
+              {{ _LINE_FEED }}
+            {%- endunless -%}
+            {{ _line | strip }}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endcapture -%}
+    {%- endif -%}
+
+    {%- capture _content -%}
+      {{ _content }}
+      {%- if _pre_before contains "</pre>" -%}<pre{{ _pres.first }}</pre>{%- endif -%}
+      {%- unless _pre_before contains "</pre>" and _pres.size == 1 -%}{{ _pres_after }}{%- endunless -%}
+    {%- endcapture -%}
+  {%- endfor -%}
+
+
+{%- comment -%} Output {%- endcomment -%}
+
+  {{ _content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 ---
-layout: none
+layout: compress
 ---
 
 <!doctype html>

--- a/feed.json
+++ b/feed.json
@@ -1,4 +1,5 @@
 ---
+layout: compress
 regenerate: true
 ---
 

--- a/feed.xml
+++ b/feed.xml
@@ -1,4 +1,5 @@
 ---
+layout: compress
 regenerate: true
 ---
 
@@ -38,7 +39,7 @@ regenerate: true
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
-      <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
+      <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}"><![CDATA[{{ post.content | strip }}]]></content>
 
       {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
       {% assign post_author = site.data.authors[post_author] | default: post_author %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,4 +1,5 @@
 ---
+layout: compress
 regenerate: true
 ---
 


### PR DESCRIPTION
從 https://github.com/penibelst/jekyll-compress-html 改寫了一個 Layout（這是 MIT License）。

主要只擷取了**移除多餘空行**的部分。並使用了 Jekyll 3.5 開始支援的 Liquid 模板**空白控制**（whitespace control），避免模板語法產生的空白。為了除錯方便，在 `development` 環境下會直接輸出原始的 HTML。

同時也將這個模板套用至 Atom Feed、JSON Feed 和 Sitemap，其中為了避免 Atom Feed 裡的 `<pre>` 內容被壓縮，改用 CDATA 輸出跳脫內容。
