### PR TITLE
Add default Open Graph image

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,12 +65,14 @@ defaults:
     values:
       layout: post
       comments: true
+      image: /assets/images/favicon-512.min.png
   - scope:
       path: _pages
       type: pages
     values:
       layout: page
       comments: false
+      image: /assets/images/favicon-512.min.png
 
 # Files
 exclude:

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -127,11 +127,7 @@
 {% endif %}
 
 {% if seo_site_twitter %}
-  {% if seo_image_path %}
-    <meta name="twitter:card" content="summary_large_image">
-  {% else %}
-    <meta name="twitter:card" content="summary">
-  {% endif %}
+  <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@{{ seo_site_twitter }}">
   {% if seo_author_twitter %}
     <meta name="twitter:creator" content="@{{ seo_author_twitter }}">


### PR DESCRIPTION
* 新增預設的 Open Graph Protocol 縮圖。目前是用 512x512 的 Favicon。
* 移除讓 Twitter 使用大型縮圖卡片的 meta tag，因為看起來有點突兀（笑）。
