### PR TITLE
Use Rakefile to build and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Jekyll
 _site
 .sass-cache
 .jekyll-metadata
+
+# HTMLProofer
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: ruby
 rvm:
 - 2.4
 
-script: bundle exec jekyll build && bundle exec htmlproofer --timeframe 30d --only-4xx ./_site
-
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'jekyll', '~> 3.5.0'
 
 group :development do
+  gem 'rake', '~> 12.0.0'
   gem 'html-proofer', '~> 3.7.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
+    rake (12.0.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -77,6 +78,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer (~> 3.7.0)
   jekyll (~> 3.5.0)
+  rake (~> 12.0.0)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,37 @@
+# coding: utf-8
+
+require 'jekyll'
+require 'html-proofer'
+
+task :default => :test
+
+desc 'Build your site'
+task :build do
+  Jekyll::Commands::Build.process({profile: true})
+end
+
+desc 'Serve your site locally'
+task :serve do
+  Jekyll::Commands::Serve.process({})
+end
+
+desc 'Clean the site (removes site output and metadata file) without building.'
+task :clean do
+  Jekyll::Commands::Clean.process({})
+end
+
+desc 'Test your site.'
+task :test => [:clean, :build] do
+  options = {
+    :file_ignore => [/google.+\.html/],
+    :check_html => true,
+    :check_opengraph => true,
+    :check_favicon => true,
+    :empty_alt_ignore => true,
+    :only_4xx => true,
+    :cache => {
+      :timeframe => '30d'
+    }
+  }
+  HTMLProofer.check_directory('./_site', options).run
+end

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ end
 desc 'Test your site.'
 task :test => [:clean, :build] do
   options = {
-    :file_ignore => [/google.+\.html/],
+    :file_ignore => ['./_site/google49cb09583e67a84f.html'],
     :check_html => true,
     :check_opengraph => true,
     :check_favicon => true,

--- a/_config.yml
+++ b/_config.yml
@@ -76,6 +76,7 @@ defaults:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - Rakefile
   - CNAME
   - README.md
   - LICENSE.txt


### PR DESCRIPTION
* 把測試的工作寫進 `Rakefile` 裡。
* Travis CI 直接可以執行 `rake` 指令，不需要再指定 `script`。
* 提供更多檢查選項給 HTMLProofer。
* 讓 Git 忽略 HTMLProofer 產生的 `tmp` 暫存資料夾。
