### PR TITLE
Bump html-proofer from v3 to v4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ end
 
 group :development do
   gem "rake", "~> 13.0.0"
-  gem "html-proofer", "~> 3.19.0"
+  gem "html-proofer", "~> 4.1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     execjs (2.8.1)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    html-proofer (3.19.4)
+    html-proofer (4.1.0)
       addressable (~> 2.3)
       mercenary (~> 0.3)
       nokogiri (~> 1.13)
@@ -26,6 +26,7 @@ GEM
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -63,7 +64,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     mini_portile2 (2.8.0)
-    nokogiri (1.13.6)
+    nokogiri (1.13.7)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -87,12 +88,13 @@ GEM
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     yell (2.2.2)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (~> 3.19.0)
+  html-proofer (~> 4.1.0)
   jekyll (~> 3.9.0)
   jekyll-coffeescript (~> 1.1.0)
   jekyll-redirect-from (~> 0.16.0)

--- a/Rakefile
+++ b/Rakefile
@@ -23,15 +23,17 @@ end
 desc "Test your site."
 task :test => [:clean, :build] do
   options = {
-    :check_html => true,
-    :check_opengraph => true,
-    :check_favicon => true,
-    :empty_alt_ignore => true,
-    :http_status_ignore => [403],
+    :check_external_hash => false,
+    :check_internal_hash => true,
+    :ignore_missing_alt => true,
+    :ignore_status_codes => [403],
     :only_4xx => true,
     :cache => {
       :storage_dir => ".jekyll-cache/html-proofer",
-      :timeframe => "30d"
+      :timeframe => {
+        :external => '30d',
+        :internal => '15d'
+      }
     }
   }
   HTMLProofer.check_directory("./_site", options).run


### PR DESCRIPTION
This pull request bumps [html-proofer](https://github.com/gjtorikian/html-proofer) from v2 to v4.
