### PR TITLE
Add webrick to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 3.9.0"
+gem "webrick", "~> 1.8.0"
 
 group :github_pages do
   gem "kramdown-parser-gfm", "~> 1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
     ttfunk (1.7.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
+    webrick (1.8.1)
     yell (2.2.2)
     zeitwerk (2.6.7)
 
@@ -121,6 +122,7 @@ DEPENDENCIES
   jekyll-sass-converter (~> 1.5.0)
   kramdown-parser-gfm (~> 1.1.0)
   rake (~> 13.0.0)
+  webrick (~> 1.8.0)
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
Ruby 3.0 no longer comes with `webrick`.

See:
- https://github.com/jekyll/jekyll/issues/8523
- https://github.com/github/pages-gem/issues/752
