### PR TITLE
Bump Ruby in GitHub Actions from 3.0 to 3.2

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Ruby environment
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.2
           bundler-cache: true
           cache-version: 0
       - name: Set up GitHub Pages


### PR DESCRIPTION
This pull request bumps Ruby version in GitHub Actions ([ruby/setup-ruby](https://github.com/ruby/setup-ruby)) from 3.0 to 3.2.

